### PR TITLE
Handle amphtml-validator nonzero exit codes and use Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+before_install:
+  - sudo apt-get install npm
+  - npm install -g amphtml-validator
+
+go:
+  - 1.x
+  - 1.11.x
+  - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # validate
 
 [![GoDoc](https://godoc.org/github.com/derat/validate?status.svg)](https://godoc.org/github.com/derat/validate)
+[![Build Status](https://travis-ci.org/derat/validate.svg?branch=master)](https://travis-ci.org/derat/validate)
 
 The `github.com/derat/validate` Go package validates:
 

--- a/amp_test.go
+++ b/amp_test.go
@@ -5,6 +5,8 @@ package validate
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -12,7 +14,7 @@ import (
 func TestAMP_Valid(t *testing.T) {
 	issues, err := AMP(context.Background(), strings.NewReader(minimalAMP))
 	if err != nil {
-		t.Error("AMP reported error: ", err)
+		t.Error("AMP reported error:", errorString(err))
 	}
 	if len(issues) != 0 {
 		t.Errorf("AMP returned issues: %v", issues)
@@ -23,7 +25,7 @@ func TestAMP_Invalid(t *testing.T) {
 	doc := strings.Replace(minimalAMP, "<html amp", "<html ", 1) + "  <bogus></bogus>\n"
 	issues, err := AMP(context.Background(), strings.NewReader(doc))
 	if err != nil {
-		t.Error("AMP reported error for invalid document: ", err)
+		t.Error("AMP reported error for invalid document:", errorString(err))
 	}
 	if len(issues) != 2 {
 		t.Errorf("AMP returned %v issues (%q); want 2", len(issues), issues)
@@ -54,6 +56,14 @@ func TestAMP_Invalid(t *testing.T) {
 			Code:     "DISALLOWED_TAG",
 		}, false /* needURL */)
 	}
+}
+
+func errorString(err error) string {
+	s := err.Error()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		s += fmt.Sprintf(" (%v)", string(exitErr.Stderr))
+	}
+	return s
 }
 
 // This comes from https://amp.dev/documentation/guides-and-tutorials/start/create/basic_markup/.

--- a/validate.go
+++ b/validate.go
@@ -190,7 +190,8 @@ func post(ctx context.Context, url string, fields map[string]string, files []fil
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, &b)
+	// TODO: Update this to use http.NewRequestWithContext (introduced in Go 1.12) someday.
+	req, err := http.NewRequest("POST", url, &b)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
amphtml-validator apparently exits with 1 when it finds an
error; I hadn't noticed this due to it running in a wrapper.
Update the code and add a config for running tests on
Travis.

Also replace an http.NewRequestWithContext (introduced in Go
1.12) call with http.NewRequest.